### PR TITLE
Update textwrap to version 0.12.0

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -35,4 +35,4 @@ default-features = false
 features = ["parsing", "full", "printing", "proc-macro"]
 
 [dependencies.textwrap]
-version = "0.11.0"
+version = "0.12.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! "#);
 //! ```
 //!
-//! Checkout the [documentation of the original library](https://docs.rs/textwrap/0.11.0/textwrap/)
+//! Checkout the [documentation of the original library](https://docs.rs/textwrap/0.12.0/textwrap/)
 //! for more information about the behaviour of each of the wrapped functions.
 //!
 //! ## Changelog
@@ -125,7 +125,6 @@ pub use textwrap_macros_impl::indent;
 ///
 /// See also [textwrap::fill](https://docs.rs/textwrap/latest/textwrap/fn.fill.html).
 pub use textwrap_macros_impl::fill;
-
 
 #[proc_macro_hack::proc_macro_hack]
 /// Wrap a line of text at width characters.


### PR DESCRIPTION
This version add support for wrapping strings with ANSI escape
sequences (used for colored text in terminals).