### PR TITLE
Update textwrap to version 0.13

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -35,4 +35,4 @@ default-features = false
 features = ["parsing", "full", "printing", "proc-macro"]
 
 [dependencies.textwrap]
-version = "0.12.0"
+version = "0.13"

--- a/impl/lib.rs
+++ b/impl/lib.rs
@@ -52,7 +52,7 @@ impl Parse for FillInput {
 #[proc_macro_hack::proc_macro_hack]
 pub fn fill(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input!(tokens as FillInput);
-    let width = input.width.base10_parse().expect("could not parse number");
+    let width: usize = input.width.base10_parse().expect("could not parse number");
     let newstr = textwrap::fill(&input.lit.value(), width);
 
     syn::LitStr::new(&newstr, input.lit.span())
@@ -105,9 +105,10 @@ impl Parse for WrapInput {
 #[proc_macro_hack::proc_macro_hack]
 pub fn wrap(tokens: TokenStream) -> TokenStream {
     let input = parse_macro_input!(tokens as WrapInput);
-    let width = input.width.base10_parse().expect("could not parse number");
+    let width: usize = input.width.base10_parse().expect("could not parse number");
 
-    let elems = textwrap::wrap_iter(&input.lit.value(), width)
+    let elems = textwrap::wrap(&input.lit.value(), width)
+        .iter()
         .map(|s| syn::Lit::from(syn::LitStr::new(&s, input.lit.span())))
         .map(|lit| syn::Expr::Lit(syn::ExprLit { lit, attrs: Vec::new() }))
         .collect();


### PR DESCRIPTION
This bumps the version to the new 0.13 release of textwrap.

The `textwrap::fill` and `textwrap::wrap` function now take a second argument which can be `usize` or something else which can be turned into `textwrap::Options`. So this required me to specify the type of the `width` variables.

The `textwrap::wrap_iter` function returned an `impl Iterator<Item = Cow<str>>`. This function is gone and has been replaced with `textwrap::wrap`, which return a `Vec<Cow<str>>`.

This makes PR #4 unnecessary.